### PR TITLE
Add missing { to package.nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -1,4 +1,4 @@
-
+{
   lib,
   stdenv,
   stdenvNoCC,


### PR DESCRIPTION
The { was deleted in the most recent commit. Reverting that typo.