### PR TITLE
fix: Update package version from 0.79.3 to 0.79.10

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -8,7 +8,7 @@
 }:
 
 let
-  version = "0.79.3";
+  version = "0.79.10";
 
   srcs = {
     "x86_64-linux" = {


### PR DESCRIPTION
Need to also check the upgrade action, it changed the hashes but not the version in the package.nix

Also: The whole setup with only the home-manager module on a non-nixOS system is currently broken other than just running the package itself. Still looking into it.