### PR TITLE
Test/refactoring module

### DIFF
--- a/.github/workflows/update-pi.yml
+++ b/.github/workflows/update-pi.yml
@@ -85,6 +85,10 @@ jobs:
         if: steps.ver.outputs.skip != 'true'
         run: bash scripts/update-node.bash "v${{ steps.ver.outputs.target }}"
 
+      - name: Check modules
+        if: steps.ver.outputs.skip != 'true'
+        run: nix build .#checks.x86_64-linux.nixos-module .#checks.x86_64-linux.home-manager-module --no-link
+
       - name: Build pi-coding-agent (prebuilt)
         if: steps.ver.outputs.skip != 'true'
         run: nix build .#pi-coding-agent --no-link

--- a/README.md
+++ b/README.md
@@ -125,10 +125,10 @@ On every system activation, the module:
 
 1. Creates `~/.pi/agent/` for each configured user.
 2. Writes (or symlinks) `models.json` and `keybindings.json` inside it.
-3. If `mutableDir = false` (default), the files are **read-only symlinks** into the Nix store — any manual edits will be lost on rebuild. The module also **guards against accidental edits**: if you mutate a mutable file and it differs from the declared config, activation will fail with a clear error message asking you to back up first.
-4. Runs `pi install <ext>` for every extension declared in `extensions`.
+3. If `mutableDir = false` (default), the files are **read-only symlinks** into the Nix store. If `mutableDir = true`, the files are copied once; activation fails if an existing file differs from the declared config.
+4. Runs `pi install <ext>` during activation for every extension declared in `extensions`.
 
-> **Note:** `models` and `keybindings` are fully replaced on every rebuild. If you need to keep local edits, set `mutableDir = true`.
+> **Note:** `models` and `keybindings` are declarative. If you need local edits, set `mutableDir = true` and update your Nix config before the next rebuild.
 
 ---
 

--- a/base-module.nix
+++ b/base-module.nix
@@ -11,6 +11,7 @@ with lib;
 
 let
   isHM = moduleType == "home-manager";
+  defaultPackage = pkgs.pi or (pkgs.callPackage ./package.nix { });
 
   attrPath =
     if isHM then
@@ -24,6 +25,10 @@ let
         "pi-coding-agent"
       ];
   cfg = getAttrFromPath attrPath config;
+
+  opts = import ./modules/options.nix {
+    inherit lib isHM defaultPackage;
+  };
 
   modelsJson = pkgs.writeText "pi-models.json" (builtins.toJSON cfg.models);
   keybindingsJson = pkgs.writeText "pi-keybindings.json" (builtins.toJSON cfg.keybindings);
@@ -53,7 +58,7 @@ let
       local uname="$4"
       local gname="$5"
       if [ -f "$target_file" ]; then
-        if ! diff -Bw "$target_file" "$source_file" > /dev/null; then
+        if ! cmp -s "$target_file" "$source_file"; then
           echo "[NIX PROTECTED ERROR]: Found inconsistency in the content of '$target_file' ($label)" >&2
           echo "Make sure that you already backup before rebuild" >&2
           exit 1
@@ -82,7 +87,7 @@ let
 
           ${concatMapStringsSep "\n" (ext: ''
             echo "[Pi Module] installing extension: ${ext}..."
-            ${piPackage}/bin/pi install '${ext}' 2>&1
+            ${piPackage}/bin/pi install ${escapeShellArg ext} 2>&1
           '') cfg.extensions}
         ''
       else
@@ -98,13 +103,13 @@ let
                 keybindingsFile = "${homeDir}/.pi/agent/keybindings.json";
 
                 installExtensionCmds = concatMapStringsSep "\n" (ext: ''
-                              echo "[Pi Module] installing extension: ${ext} for user ${username}..."
-                              runuser -l ${username} -c "export HOME=${homeDir}; ${piPackage}/bin/pi install '${ext}' 2>&1
-                  "           '') cfg.extensions;
+                  echo "[Pi Module] installing extension: ${ext} for user ${username}..."
+                  runuser -u ${escapeShellArg username} -- env HOME=${escapeShellArg homeDir} ${piPackage}/bin/pi install ${escapeShellArg ext} 2>&1
+                '') cfg.extensions;
               in
               ''
-                mkdir -p "${homeDir}/.pi/agent"
-                chown ${username}:${userConfig.group} "${homeDir}/.pi/agent"
+                install -d -o ${escapeShellArg username} -g ${escapeShellArg userConfig.group} ${escapeShellArg homeDir}/.pi
+                install -d -o ${escapeShellArg username} -g ${escapeShellArg userConfig.group} ${escapeShellArg homeDir}/.pi/agent
 
                 if ${if cfg.mutableDir then "true" else "false"}; then
                   check_and_sync "${modelsFile}" "${modelsJson}" "models" "${username}" "${userConfig.group}"
@@ -125,58 +130,7 @@ let
   '';
 in
 {
-  options = setAttrByPath attrPath (
-    {
-      enable = mkEnableOption "Pi Coding Agent";
-
-      package = mkOption {
-        type = types.package;
-        default = pkgs.pi;
-        description = "Package pi";
-      };
-
-      mutableDir = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Make config editable";
-      };
-
-      extensions = mkOption {
-        type = types.listOf types.str;
-        default = [ ];
-        description = "Auto extensions";
-      };
-
-      extraEnv = mkOption {
-        type = types.attrsOf (types.either types.str types.int);
-        default = { };
-      };
-
-      models = mkOption {
-        type = types.attrs;
-        default = { };
-        description = "Models setup";
-      };
-
-      keybindings = mkOption {
-        type = types.attrsOf (types.listOf types.str);
-        default = { };
-        description = "Keybindings";
-      };
-    }
-    // (
-      if isHM then
-        { }
-      else
-        {
-          users = mkOption {
-            type = types.listOf types.str;
-            default = [ ];
-            description = "Target users";
-          };
-        }
-    )
-  );
+  options = setAttrByPath attrPath opts;
 
   config = mkIf cfg.enable (mkMerge [
     (

--- a/base-module.nix
+++ b/base-module.nix
@@ -130,6 +130,8 @@ let
   '';
 in
 {
+  disabledModules = lib.optional isHM "programs/pi-coding-agent.nix";
+
   options = setAttrByPath attrPath opts;
 
   config = mkIf cfg.enable (mkMerge [

--- a/checks.nix
+++ b/checks.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  self,
+  home-manager,
+  eachLinuxSystem,
+}:
+
+eachLinuxSystem (
+  { pkgs, system }:
+  let
+    nixosEval = lib.nixosSystem {
+      inherit system;
+      modules = [
+        self.nixosModules.default
+        {
+          users.users.pi-test = {
+            isNormalUser = true;
+            group = "users";
+            home = "/home/pi-test";
+          };
+
+          services.pi-coding-agent = {
+            enable = true;
+            users = [ "pi-test" ];
+          };
+        }
+      ];
+    };
+
+    homeEval = home-manager.lib.homeManagerConfiguration {
+      inherit pkgs;
+      modules = [
+        self.homeManagerModules.default
+        {
+          home = {
+            username = "pi-test";
+            homeDirectory = "/home/pi-test";
+            stateVersion = "25.05";
+          };
+
+          home.enableNixpkgsReleaseCheck = false;
+          programs.pi-coding-agent.enable = true;
+        }
+      ];
+    };
+
+    nixosInfo = builtins.toJSON {
+      package = nixosEval.config.services.pi-coding-agent.package.pname;
+      activationHash = builtins.hashString "sha256" nixosEval.config.system.activationScripts.piCodingAgentConfig.text;
+    };
+
+    homeInfo = builtins.toJSON {
+      package = homeEval.config.programs.pi-coding-agent.package.pname;
+      activationHash = builtins.hashString "sha256" homeEval.config.home.activation.piCodingAgentConfig.data;
+    };
+  in
+  {
+    nixos-module = pkgs.runCommand "pi-nixos-module-check" { inherit nixosInfo; } ''
+      echo "$nixosInfo" > $out
+    '';
+
+    home-manager-module = pkgs.runCommand "pi-home-manager-module-check" { inherit homeInfo; } ''
+      echo "$homeInfo" > $out
+    '';
+  }
+)

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,25 @@
 {
   "nodes": {
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783436070,
+        "narHash": "sha256-F80z1JoiJgZyTT5D+3siLOVzqmCEphLR7t0Ym/I2CLI=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "f09af49406ffad37acb6538d3207189a1a1e0b7e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1778443072,
@@ -18,6 +38,7 @@
     },
     "root": {
       "inputs": {
+        "home-manager": "home-manager",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,24 @@
 {
   description = "Pi - Your minimal agent harness";
 
-  inputs.nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
 
   outputs =
-    { self, nixpkgs }:
+    {
+      self,
+      nixpkgs,
+      home-manager,
+    }:
     let
+      lib = nixpkgs.lib;
+
       systems = [
         "aarch64-darwin"
         "x86_64-darwin"
@@ -13,20 +26,28 @@
         "x86_64-linux"
       ];
 
-      forEachSystem =
-        f:
-        nixpkgs.lib.genAttrs systems (
+      linuxSystems = [
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+
+      forSystems =
+        targetSystems: f:
+        lib.genAttrs targetSystems (
           system:
           f {
             pkgs = nixpkgs.legacyPackages.${system};
             inherit system;
           }
         );
+
+      eachSystem = forSystems systems;
+      eachLinuxSystem = forSystems linuxSystems;
     in
     {
-      formatter = forEachSystem ({ pkgs, ... }: pkgs.nixfmt);
+      formatter = eachSystem ({ pkgs, ... }: pkgs.nixfmt);
 
-      packages = forEachSystem (
+      packages = eachSystem (
         { pkgs, system }:
         {
           pi-coding-agent = pkgs.callPackage ./package.nix { };
@@ -36,8 +57,16 @@
       );
 
       nixosModules.default = import ./module.nix;
-
       homeManagerModules.default = import ./hm-module.nix;
+
+      checks = import ./checks.nix {
+        inherit
+          lib
+          self
+          home-manager
+          eachLinuxSystem
+          ;
+      };
 
       overlays.default = final: _: {
         pi = final.callPackage ./package.nix { };

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  isHM,
+  defaultPackage,
+}:
+with lib;
+{
+  enable = mkEnableOption "Pi Coding Agent";
+
+  package = mkOption {
+    type = types.package;
+    default = defaultPackage;
+    description = "Package pi";
+  };
+
+  mutableDir = mkOption {
+    type = types.bool;
+    default = false;
+    description = "Make config editable";
+  };
+
+  extensions = mkOption {
+    type = types.listOf types.str;
+    default = [ ];
+    description = "Auto extensions";
+  };
+
+  extraEnv = mkOption {
+    type = types.attrsOf (types.either types.str types.int);
+    default = { };
+  };
+
+  models = mkOption {
+    type = types.attrs;
+    default = { };
+    description = "Models setup";
+  };
+
+  keybindings = mkOption {
+    type = types.attrsOf (types.listOf types.str);
+    default = { };
+    description = "Keybindings";
+  };
+}
+// (
+  if isHM then
+    { }
+  else
+    {
+      users = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = "Target users";
+      };
+    }
+)

--- a/package-src.nix
+++ b/package-src.nix
@@ -111,7 +111,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     makeWrapper $out/lib/pi/pi $out/bin/pi \
       --set-default PI_DATA_DIR "$HOME/.local/share/pi" \
       --set-default PI_PACKAGE_DIR "$out/lib/pi" \
-      --prefix PATH : ${lib.makeBinPath [ nodejs ]} \
+      --prefix PATH : ${lib.makeBinPath [ nodejs ]}
 
     runHook postInstall
   '';


### PR DESCRIPTION
Refactor flake checks and module validation.            
- Add Home Manager input for module eval checks         
- Move flake checks into `checks.nix`                   
- Add NixOS and Home Manager module checks              
- Run module checks in update workflow                  
- Disable upstream HM `pi-coding-agent` module to avoid option conflicts 