### PR TITLE
Improve module robustness: models schema, secret warnings, mutableDir backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In your `flake.nix` inputs:
 
 ```nix
 inputs = {
-  pi-flake.url = "github:oslamelon/pi-flake";
+  pi-flake.url = "github:ChauDucToan/pi-flake";
   # optional, if you use Home Manager:
   home-manager.url = "github:nix-community/home-manager";
 };
@@ -29,7 +29,7 @@ inputs = {
 
 ```nix
 {
-  inputs.pi-flake.url = "github:oslamelon/pi-flake";
+  inputs.pi-flake.url = "github:ChauDucToan/pi-flake";
 
   outputs = { self, nixpkgs, pi-flake }: {
     nixosConfigurations.myMachine = nixpkgs.lib.nixosSystem {
@@ -125,10 +125,21 @@ On every system activation, the module:
 
 1. Creates `~/.pi/agent/` for each configured user.
 2. Writes (or symlinks) `models.json` and `keybindings.json` inside it.
-3. If `mutableDir = false` (default), the files are **read-only symlinks** into the Nix store. If `mutableDir = true`, the files are copied once; activation fails if an existing file differs from the declared config.
+3. If `mutableDir = false` (default), the files are **read-only symlinks** into the Nix store. If `mutableDir = true`, the files are copied; activation fails if an existing file differs from the declared config. Set `mutableDirBackupOnConflict = true` to back up (`<file>.backup`) and overwrite instead of failing.
 4. Runs `pi install <ext>` during activation for every extension declared in `extensions`.
 
 > **Note:** `models` and `keybindings` are declarative. If you need local edits, set `mutableDir = true` and update your Nix config before the next rebuild.
+
+### Secrets
+
+`models.json` is a world-readable file (a symlink into the nix store, or a copy when
+`mutableDir = true`). **Never put literal API keys in `models`/`keybindings`.** pi
+supports value resolution, so prefer:
+
+- environment variables: `apiKey = "$MY_API_KEY";`
+- shell commands: `apiKey = "!op read 'op://vault/item/key'";`
+
+The module warns at eval time when it detects literal `apiKey`/`headers` values.
 
 ---
 
@@ -200,13 +211,13 @@ If you don't want the modules, just use the overlay to get the `pi` package:
 
 ```nix
 {
-  inputs.pi-flake.url = "github:oslamelon/pi-flake";
+  inputs.pi-flake.url = "github:ChauDucToan/pi-flake";
 
   outputs = { pi-flake, ... }: pi-flake.packages.x86_64-linux.default;
 }
 ```
 
-Then run `nix run github:oslamelon/pi-flake` to try Pi directly.
+Then run `nix run github:ChauDucToan/pi-flake` to try Pi directly.
 
 ---
 

--- a/base-module.nix
+++ b/base-module.nix
@@ -30,6 +30,26 @@ let
     inherit lib isHM defaultPackage;
   };
 
+  # Detect literal apiKey/header values that would be copied world-readable
+  # into the nix store. pi resolves plain strings, `$ENV_VAR` references and
+  # `!command` substitutions; warn when a plain secret is declared.
+  isLiteralSecret =
+    value:
+    lib.isString value && value != "" && !(lib.hasPrefix "$" value) && !(lib.hasPrefix "!" value);
+
+  collectLiteralSecrets =
+    providers:
+    lib.foldlAttrs (
+      acc: name: prov:
+      acc
+      ++ lib.optional (isLiteralSecret (prov.apiKey or "")) "${name}.apiKey"
+      ++ lib.mapAttrsToList (k: v: "${name}.headers.${k}") (
+        lib.filterAttrs (_: isLiteralSecret) (prov.headers or { })
+      )
+    ) [ ] providers;
+
+  literalSecrets = collectLiteralSecrets (cfg.models.providers or { });
+
   modelsJson = pkgs.writeText "pi-models.json" (builtins.toJSON cfg.models);
   keybindingsJson = pkgs.writeText "pi-keybindings.json" (builtins.toJSON cfg.keybindings);
 
@@ -59,15 +79,19 @@ let
       local gname="$5"
       if [ -f "$target_file" ]; then
         if ! cmp -s "$target_file" "$source_file"; then
-          echo "[NIX PROTECTED ERROR]: Found inconsistency in the content of '$target_file' ($label)" >&2
-          echo "Make sure that you already backup before rebuild" >&2
-          exit 1
+          if ${if cfg.mutableDirBackupOnConflict then "true" else "false"}; then
+            echo "[Pi Module] backing up modified '$target_file' ($label)..." >&2
+            cp "$target_file" "$target_file.backup"
+          else
+            echo "[NIX PROTECTED ERROR]: Found inconsistency in the content of '$target_file' ($label)" >&2
+            echo "Make sure that you already backup before rebuild" >&2
+            exit 1
+          fi
         fi
-      else
-        cp "$source_file" "$target_file"
-        if [ -n "$uname" ]; then chown "$uname:$gname" "$target_file"; fi
-        chmod 644 "$target_file"
       fi
+      cp "$source_file" "$target_file"
+      if [ -n "$uname" ]; then chown "$uname:$gname" "$target_file"; fi
+      chmod 644 "$target_file"
     }
 
     ${
@@ -153,5 +177,16 @@ in
           };
         }
     )
+    {
+      # Warn at eval time when a literal secret would end up world-readable in
+      # the nix store. Prefer `$ENV_VAR` or `!command` references instead.
+      warnings = lib.optional (literalSecrets != [ ]) ''
+        pi-coding-agent: literal secret values in `models.providers` will be
+        written world-readable into the nix store:
+          ${concatStringsSep "\n  " literalSecrets}
+        Use an environment variable reference (`$MY_API_KEY`) or a shell
+        command (`!op read ...`) instead.
+      '';
+    }
   ]);
 }

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -19,6 +19,17 @@ with lib;
     description = "Make config editable";
   };
 
+  mutableDirBackupOnConflict = mkOption {
+    type = types.bool;
+    default = false;
+    description = ''
+      When `mutableDir = true` and an existing config file differs from the
+      declared one, back it up to `<file>.backup` instead of failing the
+      activation. Only useful if you accept silently losing the declaration
+      drift on every rebuild.
+    '';
+  };
+
   extensions = mkOption {
     type = types.listOf types.str;
     default = [ ];
@@ -31,9 +42,27 @@ with lib;
   };
 
   models = mkOption {
-    type = types.attrs;
+    # Keep the providers freeform: pi's schema is extensible (custom APIs
+    # registered by extensions, per-model compat maps, etc.), and a strict
+    # submodule would inject default/null keys into the JSON that pi does not
+    # expect. We only enforce the top-level `providers` key here.
+    type = types.submodule {
+      freeformType = types.attrs;
+      options.providers = mkOption {
+        type = types.attrsOf types.attrs;
+        default = { };
+        description = "Custom providers, keyed by provider name.";
+      };
+    };
     default = { };
-    description = "Models setup";
+    description = ''
+      Models setup, written to `~/.pi/agent/models.json`. See
+      https://pi.dev/docs/latest/models for the full schema.
+
+      Prefer referencing secrets via environment variables (`$MY_API_KEY`) or a
+      shell command (`!op read ...`) instead of literal values: the file is a
+      world-readable symlink into the nix store.
+    '';
   };
 
   keybindings = mkOption {

--- a/package-src.nix
+++ b/package-src.nix
@@ -81,9 +81,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
-    if tar -tzf ${aiData} package/dist/providers/data >/dev/null 2>&1; then
-      tar -xzf ${aiData} --strip-components=3 -C packages/ai/src/providers package/dist/providers/data
+    if ! tar -tzf ${aiData} package/dist/providers/data >/dev/null 2>&1; then
+      echo "ERROR: expected package/dist/providers/data not found in ${aiData}" >&2
+      echo "The pi-ai tarball layout changed; update the extraction path in postPatch." >&2
+      exit 1
     fi
+    tar -xzf ${aiData} --strip-components=3 -C packages/ai/src/providers package/dist/providers/data
   '';
 
   configurePhase = ''


### PR DESCRIPTION
## Changes

1. **`models` schema validation** (`modules/options.nix`): enforce the top-level `providers` key while keeping provider config freeform, so pi's extensible schema (extension-registered APIs, per-model compat maps) is preserved exactly in the emitted JSON.
2. **Literal-secret warning** (`base-module.nix`): warns at eval time when an `apiKey`/`headers` value would be written world-readable into the nix store. Recommends `$ENV_VAR` or `!command` references.
3. **`mutableDirBackupOnConflict`** new option: when `mutableDir = true` and a file drifted, back it up to `<file>.backup` instead of failing activation.
4. **`package-src.nix`**: fail loudly if the `pi-ai` tarball layout changes (previously silently skipped extraction).
5. **README**: fix stale repo name, document secrets & backup behavior.

## Validation

- `nix eval .#checks.x86_64-linux.nixos-module` and `home-manager-module` pass.
- Verified warning fires for literal `apiKey`/headers, and is silent for `$ENV_VAR`/`!command` references.
- Verified models JSON output preserves exact user config (no injected defaults).