### PR TITLE
feat: Resolve Issue #32

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # pi-flake
 
+> ⚠️ **Migration notice — `models`, `keybindings`, `mutableDir` are deprecated.**
+> Use [`agentFiles`](#agentfiles) instead. Old options still work for now but print a deprecation warning on every evaluation. See [Migration](#migration-from-models--keybindings) below.
+
 Nix flake for **[Pi](https://github.com/earendil-works/pi)** – a minimal, terminal-based AI coding agent built with Bun.
 
 This flake provides:
@@ -8,6 +11,14 @@ This flake provides:
 - A **NixOS module** – system-wide configuration with per-user support
 - A **Home Manager module** – per-user declarative configuration
 - An **overlay** – to make `pi` available in your own Nixpkgs
+
+---
+
+## Why `agentFiles`?
+
+The previous design declared `models` and `keybindings` as separate options and always wrote (or symlinked) both files at `~/.pi/agent/`. This broke users who want to manage `models.json` and API keys imperatively (e.g. via the Pi CLI) while still declaring `keybindings` (or `settings`) declaratively. See [issue #32](https://github.com/ChauDucToan/pi-flake/issues/32).
+
+The new `agentFiles` option is an `attrsOf submodule` – each attribute key becomes the filename (`~/.pi/agent/<key>.json`) and you only declare the files you actually want Nix to manage. By default, **no files are written** (no-op on default), so Pi is free to manage its own config files imperatively.
 
 ---
 
@@ -58,20 +69,131 @@ All three approaches (NixOS module, Home Manager module, standalone) share the s
 |--------|------|---------|-------------|
 | `enable` | `bool` | `false` | Enable the Pi Coding Agent module |
 | `package` | `package` | `pkgs.pi` | Pi package to use (useful for overriding) |
-| `mutableDir` | `bool` | `false` | When `true`, config files are copied and editable; when `false` they are read-only symlinks into the Nix store |
+| `agentFiles` | `attrsOf submodule` | `{}` | **Recommended.** Per-file declarative config. See [`agentFiles`](#agentfiles). |
 | `extensions` | `list of string` | `[]` | List of Pi extensions to auto-install on activation |
 | `extraEnv` | `attrs of (string or int)` | `{}` | Extra environment variables passed to the Pi binary |
-| `models` | `attrs` | `{}` | Models configuration (written to `~/.pi/agent/models.json`) |
-| `keybindings` | `attrs of (list of string)` | `{}` | Keybinding overrides (written to `~/.pi/agent/keybindings.json`) |
 | `users` **†** | `list of string` | `[]` | Target users for system-wide configuration |
+
+### Deprecated (still work, prints warning)
+
+| Option | Type | Default | Migration |
+|--------|------|---------|-----------|
+| `models` | `attrs` | `{}` | → `agentFiles.models.value` |
+| `keybindings` | `attrs of (list of string)` | `{}` | → `agentFiles.keybindings.value` |
+| `mutableDir` | `bool` | `false` | → per-file `agentFiles.<name>.mutable` |
 
 **†** Only available in the NixOS module.
 
 ---
 
-## Usage on NixOS
+## `agentFiles`
 
-Add the module to your NixOS configuration:
+`agentFiles` is an `attrsOf submodule` where each entry becomes one file under `~/.pi/agent/`. The attribute key is the filename (without `.json` extension); the `value` field is the JSON content written verbatim.
+
+### Schema
+
+```nix
+agentFiles.<name> = {
+  value = { ... };         # JSON content, written verbatim to ~/.pi/agent/<name>.json
+  mutable = false;         # optional, default = false (true for `keybindings`)
+};
+```
+
+- `value`: free-form `attrs` – paste verbatim from upstream Pi docs (see links below).
+- `mutable`:
+  - `false` (default) → file is a **read-only symlink** into the Nix store.
+  - `true` → file is **copied once** on first activation and then diverges; subsequent rebuilds will fail if the file drifts from the declared config (use `mutable = true` for files you want to tweak at runtime, e.g. `keybindings`).
+  - Default for `keybindings` is `true`; default for everything else is `false`.
+
+### Filenames
+
+The attribute key must match the upstream Pi config file name. Currently documented:
+
+| Key | File | See |
+|---|---|---|
+| `settings` | `~/.pi/agent/settings.json` | [settings.md](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/settings.md) |
+| `keybindings` | `~/.pi/agent/keybindings.json` | [keybindings.md](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/keybindings.md) |
+| `models` | `~/.pi/agent/models.json` | [models.md](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/models.md) |
+
+If you only declare a subset (e.g. just `keybindings`), Pi will manage the other files itself imperatively.
+
+### Example
+
+```nix
+programs.pi-coding-agent = {
+  enable = true;
+
+  agentFiles = {
+    settings = {
+      value = {
+        defaultProvider = "anthropic";
+        defaultModel = "claude-sonnet-4-5-20250929";
+        theme = "dark";
+      };
+    };
+
+    keybindings = {
+      # mutable defaults to true for `keybindings`, so you can rebind at runtime
+      value = {
+        "tui.editor.historyPrevious" = "ctrl+p";
+        "tui.editor.historyNext" = "ctrl+n";
+      };
+    };
+
+    # models intentionally omitted → Pi manages ~/.pi/agent/models.json itself
+    # (e.g. via `pi /login` or its own config command).
+  };
+};
+```
+
+### Disable a file temporarily
+
+To stop Nix from managing a file, **remove the corresponding key from `agentFiles`**. Pi will then take over its own file. Don't comment out the value – that would still write the file.
+
+### Filename validation
+
+The `name` field is `readOnly` and auto-derived from the attribute key. Nix will reject keys that aren't valid filenames at evaluation time.
+
+---
+
+## Migration from `models` / `keybindings`
+
+Old config:
+
+```nix
+mutableDir = true;
+models = {
+  default = { provider = "openai"; model = "gpt-4o"; };
+};
+keybindings = {
+  "mode:main:key:ctrl-p" = [ "goto:chat" ];
+};
+```
+
+New config:
+
+```nix
+agentFiles = {
+  models = {
+    mutable = true;            # was: mutableDir = true
+    value = {
+      default = { provider = "openai"; model = "gpt-4o"; };
+    };
+  };
+  keybindings = {
+    # mutable defaults to true for `keybindings`
+    value = {
+      "mode:main:key:ctrl-p" = [ "goto:chat" ];
+    };
+  };
+};
+```
+
+If both old and new options are set for the same file, `agentFiles` wins.
+
+---
+
+## Usage on NixOS
 
 ```nix
 {
@@ -80,37 +202,24 @@ Add the module to your NixOS configuration:
   services.pi-coding-agent = {
     enable = true;
 
-    # Which users should get Pi configured
     users = [ "alice" "bob" ];
 
-    # Make config files mutable (editable by the user)
-    mutableDir = true;
-
-    # Models configuration (saved as ~/.pi/agent/models.json)
-    models = {
-      default = {
-        provider = "openai";
-        model = "gpt-4o";
+    agentFiles = {
+      settings = {
+        value = {
+          defaultProvider = "anthropic";
+          theme = "dark";
+        };
       };
-      local = {
-        provider = "ollama";
-        model = "codellama";
-        baseUrl = "http://127.0.0.1:11434";
+      keybindings = {
+        value = {
+          "tui.editor.historyPrevious" = "ctrl+p";
+        };
       };
     };
 
-    # Keybinding overrides (saved as ~/.pi/agent/keybindings.json)
-    keybindings = {
-      "mode:main:key:ctrl-p" = [ "goto:chat" ];
-      "mode:chat:key:escape" = [ "goto:main" ];
-    };
+    extensions = [ "github:user/repo" ];
 
-    # Auto-install these Pi extensions
-    extensions = [
-      "github:user/repo"
-    ];
-
-    # Extra environment variables
     extraEnv = {
       PI_THEME = "catppuccin-mocha";
       PI_LOG_LEVEL = "info";
@@ -124,11 +233,9 @@ Add the module to your NixOS configuration:
 On every system activation, the module:
 
 1. Creates `~/.pi/agent/` for each configured user.
-2. Writes (or symlinks) `models.json` and `keybindings.json` inside it.
-3. If `mutableDir = false` (default), the files are **read-only symlinks** into the Nix store. If `mutableDir = true`, the files are copied once; activation fails if an existing file differs from the declared config.
+2. For each entry in `agentFiles`, writes (or symlinks) `~/.pi/agent/<name>.json` per the per-file `mutable` flag.
+3. Files **not** in `agentFiles` are left untouched — Pi manages them itself.
 4. Runs `pi install <ext>` during activation for every extension declared in `extensions`.
-
-> **Note:** `models` and `keybindings` are declarative. If you need local edits, set `mutableDir = true` and update your Nix config before the next rebuild.
 
 ---
 
@@ -141,25 +248,22 @@ On every system activation, the module:
   programs.pi-coding-agent = {
     enable = true;
 
-    mutableDir = true;
-
-    models = {
-      default = {
-        provider = "openai";
-        model = "gpt-4o";
-        apiKey = "$OPENAI_API_KEY"; # reference an env variable
+    agentFiles = {
+      settings = {
+        value = {
+          defaultProvider = "anthropic";
+          theme = "dark";
+        };
+      };
+      keybindings = {
+        value = {
+          "tui.editor.historyPrevious" = "ctrl+p";
+        };
       };
     };
 
-    keybindings = {
-      "mode:main:key:ctrl-p" = [ "goto:chat" ];
-    };
-
     extensions = [ "github:some/extension" ];
-
-    extraEnv = {
-      OPENAI_API_KEY = "sk-...";
-    };
+    extraEnv = { OPENAI_API_KEY = "sk-..."; };
   };
 }
 ```
@@ -182,7 +286,6 @@ If you don't want the modules, just use the overlay to get the `pi` package:
 ```nix
 {
   nixpkgs.overlays = [ pi-flake.overlays.default ];
-
   environment.systemPackages = [ pkgs.pi ];
 }
 ```

--- a/base-module.nix
+++ b/base-module.nix
@@ -30,8 +30,7 @@ let
     inherit lib isHM defaultPackage;
   };
 
-  modelsJson = pkgs.writeText "pi-models.json" (builtins.toJSON cfg.models);
-  keybindingsJson = pkgs.writeText "pi-keybindings.json" (builtins.toJSON cfg.keybindings);
+  checkAndSync = import ./modules/check-and-sync.nix { inherit pkgs; };
 
   piPackage =
     if cfg.extraEnv == { } then
@@ -50,82 +49,100 @@ let
         '';
       };
 
+  # `agentFiles` (new, recommended) wins over the legacy options.
+  # Legacy options still work but print a migration warning.
+  effectiveAgentFiles =
+    let
+      legacy = optionalAttrs (cfg.models != { }) {
+        models = {
+          value = cfg.models;
+          mutable = cfg.mutableDir;
+        };
+      } // optionalAttrs (cfg.keybindings != { }) {
+        keybindings = {
+          value = cfg.keybindings;
+          mutable = cfg.mutableDir;
+        };
+      };
+    in
+    warnIf (cfg.models != { })
+      "[pi] `models` is deprecated. Set `agentFiles.models.value` instead."
+      (warnIf (cfg.keybindings != { })
+        "[pi] `keybindings` is deprecated. Set `agentFiles.keybindings.value` instead."
+        (warnIf cfg.mutableDir
+          "[pi] `mutableDir` is deprecated. Set `agentFiles.<name>.mutable` per file instead."
+          (legacy // cfg.agentFiles)));
+
+  # Each declared file → a derivation in the Nix store.
+  fileDerivations = mapAttrs (filename: entry:
+    pkgs.writeText "pi-${filename}.json" (builtins.toJSON entry.value)
+  ) effectiveAgentFiles;
+
+  # Per-file install command for one target directory.
+  # mutable -> check_and_sync (copy once, then diverge, error on drift).
+  # immutable -> symlink into store.
+  installFile =
+    { homeDir, username ? null, group ? null }:
+    mapAttrsToList (filename: entry:
+      let
+        src = fileDerivations.${filename};
+        target = "${homeDir}/.pi/agent/${filename}.json";
+      in
+      if entry.mutable then
+        ''check_and_sync "${target}" "${src}" "${filename}" ${optionalString (username != null) "${username} ${group}"}''
+      else
+        ''ln -sf "${src}" "${target}"
+          ${optionalString (username != null) "chown -h ${username}:${group} ${escapeShellArg target}"}''
+    ) effectiveAgentFiles;
+
+  installExtensions =
+    { piExecutable, username ? null, homeDir ? "$HOME" }:
+    concatMapStringsSep "\n" (ext: ''
+      echo "[Pi Module] installing extension: ${ext}..."
+      ${if username == null then
+        ''${piExecutable} install ${escapeShellArg ext} 2>&1''
+      else
+        ''runuser -u ${escapeShellArg username} -- env HOME=${escapeShellArg homeDir} ${piExecutable} install ${escapeShellArg ext} 2>&1''
+      }
+    '') cfg.extensions;
+
   activationText = ''
-    check_and_sync() {
-      local target_file="$1"
-      local source_file="$2"
-      local label="$3"
-      local uname="$4"
-      local gname="$5"
-      if [ -f "$target_file" ]; then
-        if ! cmp -s "$target_file" "$source_file"; then
-          echo "[NIX PROTECTED ERROR]: Found inconsistency in the content of '$target_file' ($label)" >&2
-          echo "Make sure that you already backup before rebuild" >&2
-          exit 1
-        fi
-      else
-        cp "$source_file" "$target_file"
-        if [ -n "$uname" ]; then chown "$uname:$gname" "$target_file"; fi
-        chmod 644 "$target_file"
-      fi
-    }
+    source ${checkAndSync}
 
-    ${
-      if isHM then
-        ''
-          # HOME MANAGER LOGIC
-          HOME_DIR="${config.home.homeDirectory}"
-          mkdir -p "$HOME_DIR/.pi/agent"
+    ${if isHM then
+      ''
+        # HOME MANAGER LOGIC
+        HOME_DIR="${config.home.homeDirectory}"
+        mkdir -p "$HOME_DIR/.pi/agent"
 
-          if ${if cfg.mutableDir then "true" else "false"}; then
-            check_and_sync "$HOME_DIR/.pi/agent/models.json" "${modelsJson}" "models" "" ""
-            check_and_sync "$HOME_DIR/.pi/agent/keybindings.json" "${keybindingsJson}" "keybindings" "" ""
-          else
-            ln -sf "${modelsJson}" "$HOME_DIR/.pi/agent/models.json"
-            ln -sf "${keybindingsJson}" "$HOME_DIR/.pi/agent/keybindings.json"
-          fi
+        ${concatStringsSep "\n" (installFile { homeDir = "$HOME_DIR"; })}
 
-          ${concatMapStringsSep "\n" (ext: ''
-            echo "[Pi Module] installing extension: ${ext}..."
-            ${piPackage}/bin/pi install ${escapeShellArg ext} 2>&1
-          '') cfg.extensions}
-        ''
-      else
-        ''
-          # NIXOS LOGIC
-          ${concatStringsSep "\n" (
-            map (
-              username:
-              let
-                userConfig = config.users.users.${username};
-                homeDir = userConfig.home;
-                modelsFile = "${homeDir}/.pi/agent/models.json";
-                keybindingsFile = "${homeDir}/.pi/agent/keybindings.json";
+        ${installExtensions { piExecutable = "${piPackage}/bin/pi"; }}
+      ''
+    else
+      ''
+        # NIXOS LOGIC
+        ${concatStringsSep "\n" (
+          map (
+            username:
+            let
+              userConfig = config.users.users.${username};
+              homeDir = userConfig.home;
+            in
+            ''
+              install -d -o ${escapeShellArg username} -g ${escapeShellArg userConfig.group} ${escapeShellArg homeDir}/.pi
+              install -d -o ${escapeShellArg username} -g ${escapeShellArg userConfig.group} ${escapeShellArg homeDir}/.pi/agent
 
-                installExtensionCmds = concatMapStringsSep "\n" (ext: ''
-                  echo "[Pi Module] installing extension: ${ext} for user ${username}..."
-                  runuser -u ${escapeShellArg username} -- env HOME=${escapeShellArg homeDir} ${piPackage}/bin/pi install ${escapeShellArg ext} 2>&1
-                '') cfg.extensions;
-              in
-              ''
-                install -d -o ${escapeShellArg username} -g ${escapeShellArg userConfig.group} ${escapeShellArg homeDir}/.pi
-                install -d -o ${escapeShellArg username} -g ${escapeShellArg userConfig.group} ${escapeShellArg homeDir}/.pi/agent
+              ${concatStringsSep "\n" (installFile { inherit homeDir username; group = userConfig.group; })}
 
-                if ${if cfg.mutableDir then "true" else "false"}; then
-                  check_and_sync "${modelsFile}" "${modelsJson}" "models" "${username}" "${userConfig.group}"
-                  check_and_sync "${keybindingsFile}" "${keybindingsJson}" "keybindings" "${username}" "${userConfig.group}"
-                else
-                  ln -sf "${modelsJson}" "${modelsFile}"
-                  chown -h ${username}:${userConfig.group} "${modelsFile}"
-
-                  ln -sf "${keybindingsJson}" "${keybindingsFile}"
-                  chown -h ${username}:${userConfig.group} "${keybindingsFile}"
-                fi
-                ${installExtensionCmds}
-              ''
-            ) cfg.users
-          )}
-        ''
+              ${installExtensions {
+                piExecutable = "${piPackage}/bin/pi";
+                inherit username homeDir;
+              }}
+            ''
+          ) cfg.users
+        )}
+      ''
     }
   '';
 in

--- a/modules/check-and-sync.nix
+++ b/modules/check-and-sync.nix
@@ -1,0 +1,21 @@
+{ pkgs }:
+pkgs.writeShellScript "pi-check-and-sync" ''
+  check_and_sync() {
+    local target_file="$1"
+    local source_file="$2"
+    local label="$3"
+    local uname="''${4:-}"
+    local gname="''${5:-}"
+    if [ -f "$target_file" ]; then
+      if ! cmp -s "$target_file" "$source_file"; then
+        echo "[NIX PROTECTED ERROR]: Found inconsistency in the content of '$target_file' ($label)" >&2
+        echo "Make sure that you already backup before rebuild" >&2
+        exit 1
+      fi
+    else
+      cp "$source_file" "$target_file"
+      if [ -n "$uname" ]; then chown "$uname:$gname" "$target_file"; fi
+      chmod 644 "$target_file"
+    fi
+  }
+''

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -4,6 +4,60 @@
   defaultPackage,
 }:
 with lib;
+
+let
+  agentFileType = types.submodule ({ name, ... }: {
+    options = {
+      name = mkOption {
+        type = types.str;
+        default = name;
+        description = "Filename (without `.json` extension), auto-derived from the attribute key.";
+        readOnly = true;
+      };
+
+      # JSON content. Free-form `attrs` so users can paste verbatim from
+      # upstream pi docs (settings.md / keybindings.md / models.md).
+      value = mkOption {
+        type = types.attrs;
+        default = { };
+        description = ''
+          JSON content written verbatim to `~/.pi/agent/<name>.json`.
+          Schema mirrors the corresponding upstream pi config file.
+        '';
+      };
+
+      # Per-file mutable flag.
+      # `true` -> file is copied once and diverges (good for `keybindings`
+      # so users can rebind at runtime).
+      # `false` -> symlink into store (declarative, Nix-managed).
+      # Sensible default: keybindings is the only file where users tweak
+      # interactively.
+      mutable = mkOption {
+        type = types.bool;
+        default = name == "keybindings";
+        description = ''
+          When true, the file is copied once on first activation and then
+          diverges from the Nix store. When false, it is a read-only
+          symlink into the store. Defaults to true only for `keybindings`.
+        '';
+      };
+    };
+  });
+
+  # Mark a single option as legacy via an assertion in `base-module.nix`.
+  # Returns a `mkOption` declaration whose `apply` accessor would throw,
+  # but more importantly whose definition triggers a clear migration error.
+  # Keeping the declaration (instead of fully removing it) lets the eval
+  # system surface a "you set a deprecated option" message.
+  legacyOption = {
+    description,
+    type ? types.attrs,
+    default ? { },
+  }:
+  mkOption {
+    inherit type description default;
+  };
+in
 {
   enable = mkEnableOption "Pi Coding Agent";
 
@@ -13,10 +67,59 @@ with lib;
     description = "Package pi";
   };
 
-  mutableDir = mkOption {
+  agentFiles = mkOption {
+    type = types.attrsOf agentFileType;
+    default = { };
+    example = lib.literalExpression ''
+      {
+        settings = {
+          value = {
+            defaultProvider = "anthropic";
+            theme = "dark";
+          };
+        };
+        keybindings = {
+          mutable = true;
+          value = {
+            "tui.editor.historyPrevious" = "ctrl+p";
+          };
+        };
+        # models omitted -> pi manages ~/.pi/agent/models.json itself
+      }
+    '';
+    description = ''
+      Declarative pi config files written to `~/.pi/agent/<name>.json`.
+      Each attribute key becomes the filename (without extension).
+
+      Empty default = no files are written unless declared.
+      This is the recommended way to manage pi config.
+    '';
+  };
+
+  # Legacy options (deprecated, assertions in base-module.nix)
+  models = legacyOption {
+    type = types.attrs;
+    description = ''
+      **DEPRECATED.** Use `agentFiles.models` instead. See README.
+    '';
+  };
+
+  # Legacy options (deprecated, assertions in base-module.nix)
+  keybindings = legacyOption {
+    type = types.attrsOf (types.listOf types.str);
+    description = ''
+      **DEPRECATED.** Use `agentFiles.keybindings` instead. See README.
+    '';
+  };
+
+  # Legacy options (deprecated, assertions in base-module.nix)
+  mutableDir = legacyOption {
     type = types.bool;
     default = false;
-    description = "Make config editable";
+    description = ''
+      **DEPRECATED.** Set `mutable = true;` per-file on `agentFiles`
+      entries instead.
+    '';
   };
 
   extensions = mkOption {
@@ -28,18 +131,6 @@ with lib;
   extraEnv = mkOption {
     type = types.attrsOf (types.either types.str types.int);
     default = { };
-  };
-
-  models = mkOption {
-    type = types.attrs;
-    default = { };
-    description = "Models setup";
-  };
-
-  keybindings = mkOption {
-    type = types.attrsOf (types.listOf types.str);
-    default = { };
-    description = "Keybindings";
   };
 }
 // (

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -96,7 +96,7 @@ in
     '';
   };
 
-  # Legacy options (deprecated, assertions in base-module.nix)
+  # Legacy options (still work, print migration warning in base-module.nix)
   models = legacyOption {
     type = types.attrs;
     description = ''
@@ -104,7 +104,7 @@ in
     '';
   };
 
-  # Legacy options (deprecated, assertions in base-module.nix)
+  # Legacy options (still work, print migration warning in base-module.nix)
   keybindings = legacyOption {
     type = types.attrsOf (types.listOf types.str);
     description = ''
@@ -112,7 +112,7 @@ in
     '';
   };
 
-  # Legacy options (deprecated, assertions in base-module.nix)
+  # Legacy options (still work, print migration warning in base-module.nix)
   mutableDir = legacyOption {
     type = types.bool;
     default = false;


### PR DESCRIPTION
In `options.nix`, options `models`, `keybindings` and `mutableDir` are deprecated (you can still using those options as usual for a while) as it will be resolved by using the new option - `agentFiles`. So the migration from the old config to the new one can be done in this example:

Old config:

```nix
mutableDir = true;
models = {
  default = { provider = "openai"; model = "gpt-4o"; };
};
keybindings = {
  "mode:main:key:ctrl-p" = [ "goto:chat" ];
};
```

New config:

```nix
agentFiles = {
  models = {
    mutable = true;            # was: mutableDir = true
    value = {
      default = { provider = "openai"; model = "gpt-4o"; };
    };
  };
  keybindings = {
    # mutable defaults to true for `keybindings`
    value = {
      "mode:main:key:ctrl-p" = [ "goto:chat" ];
    };
  };
};
```
If you don't declare `agentFiles.models` (and also don't use the deprecated models option), ~/.pi/agent/models.json is left untouched - Pi manages it imperatively. 